### PR TITLE
readme: add `systemctl daemon-reload` to config steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ WantedBy=multi-user.target
 Then we'll add this service to the autostart and run it:
 
 ```sh
+sudo systemctl daemon-reload
 sudo systemctl enable missed-blocks-checker
 sudo systemctl start missed-blocks-checker
 sudo systemctl status missed-blocks-checker # validate it's running


### PR DESCRIPTION
This is required for the daemon to pick up any new configurations.